### PR TITLE
Added sanity check

### DIFF
--- a/claims/claim.js
+++ b/claims/claim.js
@@ -225,5 +225,11 @@ Claim.prototype.makeAllClaims = function() {
   }
 }
 
+//sanity check
+if($('h3:contains("Module")').text().substr(8) != config.module){
+	alert("Ensure that the module in config matches that of this page.") //else you will have invisible claims taking up your time.
+	throw new Error("Incorrect module in config.");
+}
+
 var c = new Claim(config);
 // c.makeAllClaims();


### PR DESCRIPTION
If you input the wrong module, the system will let it pass but it will not be visible - the result is that you will have claims for the wrong module you cannot delete. And you cannot claim for the correct module because the wrong module will put too many hours in the system.
