### PR TITLE
Added Disclaimer message

### DIFF
--- a/claims/claim.js
+++ b/claims/claim.js
@@ -17,6 +17,10 @@ var Claim = function () {
   // ***********************************************************
   // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
   // ***********************************************************
+  
+  var currentHoursClaimedMessage = 'Current hours claimed: ';
+  var proposedClaimHoursMessage = 'Proposed hours: ';
+  var claimObjectCreateSuccessMessage = 'Claim object successfully created. Run c.makeAllClaims() to start.';
 
   var ACTIVITY_DICT = {};
   // IMPORTANT: Not all categories may be availale for your module!!
@@ -117,9 +121,9 @@ var Claim = function () {
     });
 
     this.ajax_index = 0; // index to keep track of the current ajax call
-    console.debug('Current hours claimed: ' + this.existing_hours);
-    console.debug('Proposed hours: ' + this.proposed_hours);
-    console.debug('Claim object successfully created. Run c.makeAllClaims() to start.');
+    console.debug(currentHoursClaimedMessage + this.existing_hours);
+    console.debug(proposedClaimHoursMessage + this.proposed_hours);
+    console.debug(claimObjectCreateSuccessMessage);
   }
 
   Claim.ASSIGNMENT_MARKING = ASSIGNMENT_MARKING;

--- a/claims/claim.js
+++ b/claims/claim.js
@@ -21,6 +21,7 @@ var Claim = function () {
   var currentHoursClaimedMessage = 'Current hours claimed: ';
   var proposedClaimHoursMessage = 'Proposed hours: ';
   var claimObjectCreateSuccessMessage = 'Claim object successfully created. Run c.makeAllClaims() to start.';
+  var disclaimerMessage = 'Disclaimer: By using this script, you agree to take full responsibility and fully liability for the claims you are submitting. This program is released open-sourced under the MIT License at https://github.com/nusmodifications/nus-scripts.';
 
   var ACTIVITY_DICT = {};
   // IMPORTANT: Not all categories may be availale for your module!!
@@ -124,6 +125,7 @@ var Claim = function () {
     console.debug(currentHoursClaimedMessage + this.existing_hours);
     console.debug(proposedClaimHoursMessage + this.proposed_hours);
     console.debug(claimObjectCreateSuccessMessage);
+    console.debug(disclaimerMessage);
   }
 
   Claim.ASSIGNMENT_MARKING = ASSIGNMENT_MARKING;


### PR DESCRIPTION
As with Emmanuel's comment on my FB share, I figure that it'd be good to place a disclaimer prior to the use of the script. The disclaimer should point out that this repo's source code has been released under MIT License and the authors and contributors are not liable of claim and damages related to the use of this program. 

The message shows when the claim object gets created. (i.e. before `c.makeAllClaims()` get called)