### PR TITLE
[Claims] Replace all rawgit urls with github pages URLs

### DIFF
--- a/claims/claim-example.js
+++ b/claims/claim-example.js
@@ -80,7 +80,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://rawgit.com/nusmodifications/nus-soc-scripts/master/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {

--- a/claims/module-claims/claim-cs1010s-40hrs.js
+++ b/claims/module-claims/claim-cs1010s-40hrs.js
@@ -96,7 +96,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://rawgit.com/nusmodifications/nus-scripts/master/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {

--- a/claims/module-claims/claim-cs1010s.js
+++ b/claims/module-claims/claim-cs1010s.js
@@ -112,7 +112,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://rawgit.com/nusmodifications/nus-scripts/master/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {

--- a/claims/module-claims/claim-cs1010x-ay1516s2.js
+++ b/claims/module-claims/claim-cs1010x-ay1516s2.js
@@ -73,7 +73,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://rawgit.com/nusmodifications/nus-scripts/master/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {

--- a/claims/module-claims/claim-cs1101s.js
+++ b/claims/module-claims/claim-cs1101s.js
@@ -188,7 +188,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://yyc.github.io/nus-scripts/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {

--- a/claims/module-claims/claim-cs2010-lab.js
+++ b/claims/module-claims/claim-cs2010-lab.js
@@ -72,7 +72,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://rawgit.com/nusmodifications/nus-scripts/master/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {

--- a/claims/module-claims/claim-cs3216.js
+++ b/claims/module-claims/claim-cs3216.js
@@ -47,7 +47,7 @@ var config = {
 
     // 2018: 24 hours of assignment marking and 6 hours of course material preparation!
 
-    for (var week = 4; week <= 10; week+=2) {
+    for (var week = 4; week <= 10; week += 2) {
       activities_list.push({
         activity_type: Claim.ASSIGNMENT_MARKING,
         week: week,
@@ -63,9 +63,9 @@ var config = {
         end_time: '1900'
       });
     }
-    
+
     activities_list.push({
-      activity_type: Claim.COURSE_MATERIAL_PREPARATION,  // Now called "Course Material Creation".
+      activity_type: Claim.COURSE_MATERIAL_PREPARATION, // Now called "Course Material Creation".
       week: 1,
       day: 'MONDAY',
       start_time: '0900',
@@ -80,16 +80,16 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-if (!STUDENT_ID) {  // Chrome does not allow window.prompt() to run on an inactive tab.
+if (!STUDENT_ID) { // Chrome does not allow window.prompt() to run on an inactive tab.
   alert('Please modify STUDENT_ID in the code, or run STUDENT_ID="a0123456" before pasting and running the code.');
 } else {
-  var core_script = 'https://yyc.github.io/nus-scripts/claims/claim.js';
+  var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
   var c = undefined;
   $.getScript(core_script)
     .done(function () {
       c = new Claim(config);
     })
-    .fail(function (jqxhr, settings, exception ) {
+    .fail(function (jqxhr, settings, exception) {
       console.warn('Error loading script');
       console.warn(jqxhr);
       console.warn(exception);

--- a/claims/module-claims/claim-cs3217.js
+++ b/claims/module-claims/claim-cs3217.js
@@ -88,7 +88,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://rawgit.com/nusmodifications/nus-scripts/master/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {

--- a/claims/module-claims/claim-cs3240.js
+++ b/claims/module-claims/claim-cs3240.js
@@ -57,7 +57,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://rawgit.com/nusmodifications/nus-scripts/master/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {

--- a/claims/module-claims/claim-cs3281.js
+++ b/claims/module-claims/claim-cs3281.js
@@ -115,7 +115,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://rawgit.com/nusmodifications/nus-scripts/master/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {

--- a/claims/module-claims/cs2010-tutorial.js
+++ b/claims/module-claims/cs2010-tutorial.js
@@ -111,7 +111,7 @@ var config = {
 // DO NOT CHANGE THE BOTTOM UNLESS YOU KNOW WHAT YOU ARE DOING
 // ***********************************************************
 
-var core_script = 'https://rawgit.com/nusmodifications/nus-scripts/master/claims/claim.js';
+var core_script = 'https://nusmodifications.github.io/nus-scripts/claims/claim.js';
 var c = undefined;
 $.getScript(core_script)
   .done(function () {


### PR DESCRIPTION
Rawgit is EOL and depending on that breaks all the claims scripts so I published the repo on github pages and now we can call the script from there.